### PR TITLE
Fix a few minor issues

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -9,7 +9,7 @@ universal_domainname: mycoolwebsite.com
 backend: true
 
 # Turn the dashboard widget on or off
-widget: true
+widget: false
 
 # NOTE: the 'ga_profile_id' is _not_ the same as the 'webproperty'.
 #

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -1,8 +1,8 @@
 # Note: Replace this with your Google Analytics webproperty-id. It looks
 # something like UA-12345678-1. Be sure to include the "UA-"-part.
-webproperty: UA-12345678-1
+webproperty: 
 
-universal: false
+universal: true
 universal_domainname: mycoolwebsite.com
 
 # Turn on or off the backend statistics view

--- a/src/GoogleAnalyticsExtension.php
+++ b/src/GoogleAnalyticsExtension.php
@@ -69,12 +69,16 @@ class GoogleAnalyticsExtension extends SimpleExtension
     {
         $app = $this->getContainer();
 
-        $analyticsCode = (new Snippet())
-            ->setZone(Zone::FRONTEND)
-            ->setLocation(Target::END_OF_HEAD)
-            ->setCallback([$app['ga.snippet.analytics'], "insertAnalytics"]);
+        $assets = [];
 
-        $assets = [ $analyticsCode ];
+        if ($app['ga.config.config']->getWebproperty()) {
+            $analyticsCode = (new Snippet())
+                ->setZone(Zone::FRONTEND)
+                ->setLocation(Target::END_OF_HEAD)
+                ->setCallback([$app['ga.snippet.analytics'], "insertAnalytics"]);
+
+            $assets[] = $analyticsCode;
+        }
 
         if ($app['ga.config.config']->isWidget()) {
             $widgetObj = new \Bolt\Asset\Widget\Widget();


### PR DESCRIPTION
* Check that we have a code before adding snippet
* Don't crash on dashboard by default
* Default to universal and to empty property (Because "100% of Google Analytics properties have been transferred to Universal Analytics" and we only want to add the snippet if we have a tracking code.)