### PR TITLE
Fix when we have more than 1000 profiles

### DIFF
--- a/src/Handler/GoogleAnalyticsHandler.php
+++ b/src/Handler/GoogleAnalyticsHandler.php
@@ -107,7 +107,12 @@ class GoogleAnalyticsHandler
 
         // Get the list of profiles for the authorized user.
         $profiles = $this->getAnalytics()->management_profiles->listManagementProfiles("~all", "~all");
-
+    
+        // If the service account has access to more than 1000 profiles
+        if (count($profiles->getItems()) > 999) {
+            return $specified_profile_id;
+        }
+        
         //Verify user has profiles
         if (count($profiles->getItems()) > 0) {
 


### PR DESCRIPTION
If the service account has access to more than 1000 profiles it will only return 1000, so we can't be sure if our id is among them. In that case just try to proceed with it anyway.