### PR TITLE
Add ip anonymization support

### DIFF
--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -8,6 +8,9 @@ universal_domainname: mycoolwebsite.com
 # Turn on or off the backend statistics view
 backend: true
 
+# Enable ip anonymization
+anonymize_ip: false
+
 # Turn the dashboard widget on or off
 widget: false
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -178,4 +178,24 @@ class Config extends ParameterBag
 
         return $this;
     }
+
+    /**
+     * @param bool $anonymizeIp
+     *
+     * @return Config
+     */
+    public function setAnonymizeIp($anonymizeIp)
+    {
+        $this->set('anonymize_ip', (bool) $anonymizeIp);
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAnonymizeIp()
+    {
+        return $this->getBoolean('anonymize_ip');
+    }
 }

--- a/src/GoogleAnalyticsExtension.php
+++ b/src/GoogleAnalyticsExtension.php
@@ -108,6 +108,7 @@ class GoogleAnalyticsExtension extends SimpleExtension
         $config = $this->getConfig();
         // Set the webproperty to be used whether or not universal is used or not
         $context['webproperty'] = $config['webproperty'];
+        $context['anonymize_ip'] = $config['anonymize_ip'];
 
         // Check to see if universal is set
         if ((bool) $config['universal']) {

--- a/templates/normal.twig
+++ b/templates/normal.twig
@@ -3,6 +3,9 @@
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', '{{ webproperty }}']);
     _gaq.push(['_setDomainName', '{{ domainname }}']);
+    {% if anonymize_ip is true %}
+    _gaq.push (['_gat._anonymizeIp']);
+    {% endif %}
     _gaq.push(['_trackPageview']);
 
     (function() {

--- a/templates/universal.twig
+++ b/templates/universal.twig
@@ -5,5 +5,8 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
     ga('create', '{{ webproperty }}', '{{ domainname }}');
+    {% if anonymize_ip is true %}
+    ga('set', 'anonymizeIp', true);
+    {% endif %}
     ga('send', 'pageview');
 </script>


### PR DESCRIPTION
Because of the GDPR, it is recommended (by the Dutch Data Protection Authority but I assume this is true for all GDPR countries) to enable IP anonymization with google Analytics.

So I added this to my own project and I thought I'd share it. 

[Info about the option on Google docs](https://support.google.com/analytics/answer/2763052?hl=en)
[Guide for setting up Google Analytics (in Dutch) ](https://autoriteitpersoonsgegevens.nl/sites/default/files/atoms/files/138._handleiding_privacyvriendelijk_instellen_google_analytics_aug_2018.pdf)